### PR TITLE
feat: Support `JdkPath` argument in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,12 @@ sbt clean stage
 ```
 ./inkspect_java_repl
 ```
+
+# Options
+
+```
+-s, --source <value>    source code directory to analyze
+-j, --jdk-path <value>  JDK path for type resolution (default: $JAVA_HOME)
+--help                  Show this help message
+--version               Show version information
+```

--- a/src/main/scala/com/github/inkspect/java_cli/Main.scala
+++ b/src/main/scala/com/github/inkspect/java_cli/Main.scala
@@ -7,7 +7,7 @@ object Main {
   def main(args: Array[String]): Unit = {
     CommandLineConfiguration.parse(args) match {
       case Some(options) =>
-        AnalyzeSourceCodeUseCase().execute(options.src)
+        AnalyzeSourceCodeUseCase().execute(sourcePath = options.src, jdkPath = options.jdkPath)
       case None =>
         // arguments are bad, error message will have been displayed
         sys.exit(1)

--- a/src/main/scala/com/github/inkspect/java_cli/application/usecases/AnalyzeSourceCodeUseCase.scala
+++ b/src/main/scala/com/github/inkspect/java_cli/application/usecases/AnalyzeSourceCodeUseCase.scala
@@ -13,12 +13,12 @@ import io.joern.dataflowengineoss.queryengine.EngineContext
 
 
 class AnalyzeSourceCodeUseCase() {
-  def execute(sourcePath: String): Unit = {
+  def execute(sourcePath: String, jdkPath: String): Unit = {
     println("Hello Joern")
     println(s"Analyzing: ${sourcePath}")
 
     print("Creating CPG... ")
-    val joernConfig    = Config().withInputPath(sourcePath)
+    val joernConfig    = Config().withInputPath(sourcePath).withJdkPath(jdkPath)
     val cpgOrException = JavaSrc2Cpg().createCpg(joernConfig)
 
     cpgOrException match {

--- a/src/main/scala/com/github/inkspect/java_cli/infrastructure/cli/Config.scala
+++ b/src/main/scala/com/github/inkspect/java_cli/infrastructure/cli/Config.scala
@@ -2,7 +2,11 @@ package com.github.inkspect.java_cli.infrastructure.cli
 
 import scopt.OParser
 
-case class CommandLineOptions(src: String = "", verbose: Boolean = false, command: String = "scan")
+case class CommandLineOptions(
+  src: String = "",
+  verbose: Boolean = false,
+  jdkPath: String = sys.env.getOrElse("JAVA_HOME", "")
+)
 
 object CommandLineConfiguration {
   def parser: OParser[Unit, CommandLineOptions] = {
@@ -16,9 +20,9 @@ object CommandLineConfiguration {
         .required()
         .action((x, c) => c.copy(src = x))
         .text("source code directory to analyze"),
-      cmd("scan")
-        .action((_, c) => c.copy(command = "scan"))
-        .text("Scan Java source code"),
+      opt[String]('j', "jdk-path")
+        .action((x, c) => c.copy(jdkPath = x))
+        .text(s"JDK path for type resolution (default: ${sys.env.getOrElse("JAVA_HOME", "system default")})"),
       help("help").text("Show this help message"),
       version("version").text("Show version information")
     )


### PR DESCRIPTION
The `JavaSrc2Cpg` tool must use the JDK version matching the analyzed source code, rather than the JDK used to build the CLI itself. This ensures compatibility and accurate analysis of the target codebase.

This PR adds a `JdkPath` argument to the CLI, allowing users to explicitly specify the JDK path for the analyzed source code.